### PR TITLE
Add dependency to cmake_modules for indigo since FindEigen cannot be fou...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ message("##############################")
 ############################
 # Dependecies              #
 ############################
+find_package(cmake_modules REQUIRED)
 find_package(catkin REQUIRED)
 find_package(Eigen REQUIRED)
 


### PR DESCRIPTION
...nd.

The hydro and grovy releases should work as well with the included dependency, but not tested.

Ref: http://answers.ros.org/question/188628/catkin_make-eigen-indigo/
